### PR TITLE
Low: crmd: Removes unnecessary error message from lrmd event processing.

### DIFF
--- a/crmd/lrm.c
+++ b/crmd/lrm.c
@@ -1905,8 +1905,12 @@ process_lrm_event(lrmd_event_data_t * op)
         send_direct_ack(NULL, NULL, NULL, op, op->rsc_id);
 
     } else if (pending == NULL) {
-        crm_err("Op %s (call=%d): No 'pending' entry", op_key, op->call_id);
-
+        /* Operations that are cancelled may safely be removed
+         * from the pending op list before the lrmd completion event
+         * is received. Only report non-cancelled ops here. */
+        if (op->op_status != PCMK_LRM_OP_CANCELLED) {
+            crm_err("Op %s (call=%d): No 'pending' entry", op_key, op->call_id);
+        }
     } else if (op->user_data == NULL) {
         crm_err("Op %s (call=%d): No user data", op_key, op->call_id);
 


### PR DESCRIPTION
It is safe to ignore cancelled operations that do not have a pending
operation associated with them in the lrm glue code.  With the previous
lrmd, we did not expect to hear about a cancelled operation after
executing the client command to cancel it.  The new lrmd will
notify everyone that the cancel completed (including the client
originally executing the cancel) through the ipc event channel.
